### PR TITLE
Fs exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const fs = require('fs')
 const path = require('path')
-
 const stringifyHtml = require('./lib/stringifyHtml')
 const createFilesArr = require('./lib/createFilesArr')
 const prioritizeFiles = require('./lib/prioritizeFiles')
@@ -10,7 +8,7 @@ const writeSeedScript = require('./lib/writeSeedScript')
 const getMagnetURI = require('./lib/getMagnetURI')
 const injectScript = require('./lib/injectScript')
 const writeNewHtml = require('./lib/writeNewHtml')
-let botGenerator // = require('./lib/botGenerator')
+let botGenerator
 
 /**
 * @param {Object} options


### PR DESCRIPTION
Removes fs.exists. It is fully deprecated and breaks the build. Instead we remove the option entirely and set the wfPath based on server root. 

Sets botGenerator require module based on check for devMode. This is similar to how we handled devMode and Xvfb in WebFlight. Prevents Reference error looking for Xvfb in botGenerator.js even though devMode is set to true. 
